### PR TITLE
feat: add buffer to avoid time window with low counts and thus random percentiles

### DIFF
--- a/src/docs/parameters.adoc
+++ b/src/docs/parameters.adoc
@@ -13,31 +13,54 @@ The preferred way to configure the client is to use environment variables. Below
 | _<mandatory>_
 | The Kafka topic to produce to and consume from.
 
+| `SYNTH_CLIENT_RACK`
+| "default"
+| Some identifier of the environment in which the client is running. For example "eu-west-1a". This is useful for measuring latencies between clients that are running in different environments. Can be left unset if not needed. If you have multiple racks, then be sure to assign a unique consumer group ID to each rack.
+
 | `SYNTH_CLIENT_MESSAGES_MESSAGE_SIZE_BYTES`
 | 8
 | The size of each Kafka message in bytes.
 
 | `SYNTH_CLIENT_MESSAGES_MESSAGES_PER_SECOND`
-| 1
+| 10
 | The number of messages to produce per second.
 
-
 | `SYNTH_CLIENT_MESSAGES_IGNORE_FIRST_N_MESSAGES`
-| 1
+| 10
 | The number of messages (per partition) to ignore before starting to measure latencies. This is useful for avoiding adding noise to the metrics when the consumer group is being rebalanced. The default value should be sufficient.
 
+| `SYNTH_CLIENT_SAMPLING_TIME_WINDOW`
+| 2m
+| Duration length of the time window for which to calculate the latencies. The default value should be sufficient.
 
-| `SYNTH_CLIENT_RACK`
-| "default"
-| Some identifier of the environment in which the client is running. For example "eu-west-1a". This is useful for measuring latencies between clients that are running in different environments. Can be left unset if not needed. If you have multiple racks, then be sure to assign a unique consumer group ID to each rack.
+| `SYNTH_CLIENT_MIN_SAMPLES_FIRST_WINDOW`
+| 100
+| Number of samples before percentiles are calculated. The default value should be sufficient.
 
 | `SYNTH_CLIENT_AUTO_CREATE_TOPIC`
 | true
 | If the topic is managed by the synth client and also created by the synth client. This requires `CREATE` permissions.
 
+| `SYNTH_CLIENT_TIME_SERVERS`
+| time.google.com
+| NTP server to use for time synchronization.
+
 | `SYNTH_CLIENT_TOPIC_REPLICATION_FACTOR`
 | 1
 | Replication factor to use when creating the topic.
+
+
+| `SYNTH_CLIENT_PUBLISH_HISTOGRAM_BUCKETS`
+| false
+| Will publish the histogram buckets to the metrics endpoint if enabled. `..., synth_client_e2e_latency_ms_bucket{...,le="41.0",} 902.0, synth_client_e2e_latency_ms_bucket{...,le="46.0",} 902.0, ...`
+
+| `SYNTH_CLIENT_EXPECTED_MIN_LATENCY`
+| 1.0
+| Minimum expected latency in milliseconds. Used to create histogram buckets when enabled.
+
+| `SYNTH_CLIENT_EXPECTED_MAX_LATENCY`
+| 1.0
+| Maximum expected latency in milliseconds. Used to create histogram buckets when enabled.
 
 | `QUARKUS_HTTP_PORT`
 | 8081

--- a/src/main/java/io/spoud/config/SynthClientConfig.java
+++ b/src/main/java/io/spoud/config/SynthClientConfig.java
@@ -1,26 +1,32 @@
 package io.spoud.config;
 
 import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.WithDefault;
+
+import java.time.Duration;
 
 @ConfigMapping(prefix = "synth-client")
 public interface SynthClientConfig {
     String topic();
 
-    @WithDefault("")
     String rack();
 
-    @WithDefault("1")
     int consumersCount();
 
-    @WithDefault("time.google.com")
     String timeServers();
 
     SynthClientConfigMessages messages();
 
-    @WithDefault("true")
     boolean autoCreateTopic();
 
-    @WithDefault("1")
     int topicReplicationFactor();
+
+    Duration samplingTimeWindow();
+
+    int minSamplesFirstWindow();
+
+    boolean publishHistogramBuckets();
+
+    Double expectedMinLatency();
+
+    Double expectedMaxLatency();
 }

--- a/src/main/java/io/spoud/config/SynthClientConfigMessages.java
+++ b/src/main/java/io/spoud/config/SynthClientConfigMessages.java
@@ -3,6 +3,8 @@ package io.spoud.config;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
+import java.time.Duration;
+
 public interface SynthClientConfigMessages {
     int messageSizeBytes();
     int messagesPerSecond();
@@ -14,7 +16,6 @@ public interface SynthClientConfigMessages {
      *
      * @return number of messages to ignore
      */
-    @WithDefault("1")
     @WithName("ignore-first-n-messages")
     int ignoreFirstNMessages();
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,19 @@
 quarkus.http.port=8081
 
-synth-client.topic=demo.prod.app.kafka-synth.messages
-synth-client.messages.message-size-bytes=8
-synth-client.messages.messages-per-second=1
+#quarkus.log.category."io.spoud".level=DEBUG
+
 synth-client.rack=default
+synth-client.topic=demo.prod.app.kafka-synth.messages
+synth-client.consumers-count=1
+synth-client.messages.message-size-bytes=8
+synth-client.messages.messages-per-second=10
+synth-client.messages.ignore-first-n-messages=50
+synth-client.time-servers=time.google.com
+synth-client.sampling-time-window=2m
+synth-client.publish-histogram-buckets=false
+synth-client.expected-min-latency=1.0
+synth-client.expected-max-latency=5000.0
+synth-client.min-samples-first-window=100
 synth-client.auto-create-topic=true
 synth-client.topic-replication-factor=1
 

--- a/src/test/java/io/spoud/FirstSampleWindow1TestProfile.java
+++ b/src/test/java/io/spoud/FirstSampleWindow1TestProfile.java
@@ -1,0 +1,16 @@
+package io.spoud;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class FirstSampleWindow1TestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "%test.synth-client.min-samples-first-window", "1",
+                "%test.synth-client.messages.ignore-first-n-messages", "0"
+        );
+    }
+}

--- a/src/test/java/io/spoud/KafkaSynthClientTest.java
+++ b/src/test/java/io/spoud/KafkaSynthClientTest.java
@@ -2,6 +2,7 @@ package io.spoud;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.restassured.RestAssured;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(KafkaCompanionResource.class)
+@TestProfile(FirstSampleWindow1TestProfile.class)
 public class KafkaSynthClientTest {
     @InjectKafkaCompanion
     KafkaCompanion kafkaCompanion;
@@ -52,7 +54,7 @@ public class KafkaSynthClientTest {
     @DisplayName("End-to-end latency metrics are recorded")
     public void testEndToEndLatencyRecorded() {
         kafkaCompanion.consumeWithDeserializers(ByteArrayDeserializer.class)
-                .fromTopics(config.topic(), 3)
+                .fromTopics(config.topic(), 30)
                 .awaitCompletion(Duration.ofSeconds(5));
 
         var metrics = RestAssured.get("/q/metrics").asString();
@@ -69,7 +71,7 @@ public class KafkaSynthClientTest {
     @DisplayName("Ack latency metrics are recorded")
     public void testAckLatencyRecorded() {
         kafkaCompanion.consumeWithDeserializers(ByteArrayDeserializer.class)
-                .fromTopics(config.topic(), 3)
+                .fromTopics(config.topic(), 30)
                 .awaitCompletion(Duration.ofSeconds(5));
 
         var metrics = RestAssured.get("/q/metrics").asString();

--- a/src/test/java/io/spoud/TimeServiceTest.java
+++ b/src/test/java/io/spoud/TimeServiceTest.java
@@ -8,6 +8,8 @@ import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TimeServiceTest {
@@ -51,6 +53,30 @@ class TimeServiceTest {
                 return 1;
             }
 
+            @Override
+            public Duration samplingTimeWindow() {
+                return null;
+            }
+
+            @Override
+            public int minSamplesFirstWindow() {
+                return 0;
+            }
+
+            @Override
+            public boolean publishHistogramBuckets() {
+                return false;
+            }
+
+            @Override
+            public Double expectedMinLatency() {
+                return 1.0;
+            }
+
+            @Override
+            public Double expectedMaxLatency() {
+                return 5000.0;
+            }
         });
 
         timeService.updateClockOffset(); // make sure that this even works without exceptions


### PR DESCRIPTION
- improves the percentiles published on startup
- expose histogram limits and option to expose buckets
- concentrated defaults in application.properties
- documentation of parameters


![image](https://github.com/user-attachments/assets/3a907849-74cc-433d-8824-c6d61d92c294)
