### PR TITLE
query produce-error-rate directly from producer object

### DIFF
--- a/src/main/java/io/spoud/kafka/MessageConsumer.java
+++ b/src/main/java/io/spoud/kafka/MessageConsumer.java
@@ -95,7 +95,7 @@ public class MessageConsumer implements Runnable, HealthCheck, AutoCloseable {
                     metricService.recordLatency(message.topic(), message.partition(), consumeTime - produceTime, fromRack);
                     lastReport.updateAndGet(last -> {
                         if (Duration.between(last, Instant.now()).getSeconds() > 10) {
-                            Log.infov("Consumed {0} {1} messages/seconds", index,counter.getAndSet(0) / 10.0);
+                            Log.infov("Consumer {0}: {1} messages/second", index,counter.getAndSet(0) / 10.0);
                             return Instant.now();
                         }
                         return last;

--- a/src/main/java/io/spoud/kafka/MessageProducer.java
+++ b/src/main/java/io/spoud/kafka/MessageProducer.java
@@ -1,14 +1,16 @@
 package io.spoud.kafka;
 
+import io.micrometer.core.instrument.Tags;
 import io.quarkus.logging.Log;
 import io.spoud.MetricService;
 import io.spoud.TimeService;
 import io.spoud.config.SynthClientConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
-import jakarta.inject.Qualifier;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.MetricName;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
@@ -16,28 +18,55 @@ import org.eclipse.microprofile.health.Liveness;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static io.spoud.MetricService.TAG_RACK;
 
 @Liveness
 @Default
 @ApplicationScoped
 public class MessageProducer implements HealthCheck {
+    public static final String PRODUCE_ERROR_RATE_METER_NAME = "synth-client.producer.error-rate";
+
     private final KafkaFactory kafkaFactory;
     private final MetricService metricService;
     private final TimeService timeService;
     private final SynthClientConfig config;
     private final AtomicReference<Instant> lastMessage = new AtomicReference<>(Instant.now());
+    private final String clientId;
     private KafkaProducer<Long, byte[]> producer;
 
     public static final String HEADER_RACK = "rack";
 
     public MessageProducer(KafkaFactory kafkaFactory, SynthClientConfig config,
-                           MetricService metricService, TimeService timeService) {
+                           MetricService metricService, TimeService timeService,
+                           @ConfigProperty(name = "kafka.client.id") String kafkaClientId) {
         this.kafkaFactory = kafkaFactory;
         this.config = config;
         this.metricService = metricService;
         this.timeService = timeService;
+        this.clientId = kafkaClientId;
         producer = kafkaFactory.createProducer();
+        metricService.addGauge(PRODUCE_ERROR_RATE_METER_NAME, Tags.of(TAG_RACK, config.rack()), this, MessageProducer::getSendErrorRate);
+    }
+
+    public double getSendErrorRate() {
+        var metricName = new MetricName("record-error-rate",
+                "producer-metrics",
+                "The average per-second number of record sends that resulted in errors",
+                Map.of("client-id", clientId));
+        return Optional.of(producer)
+                .map(KafkaProducer::metrics)
+                .map(m -> m.get(metricName))
+                .stream()
+                .mapToDouble((m) -> (double)m.metricValue())
+                .findFirst()
+                .orElseGet(() -> {
+                    Log.warn("send-error-rate metric not available");
+                    return -1.0;
+                });
     }
 
     public void recreateProducer() {

--- a/src/test/java/io/spoud/KafkaSynthClientTest.java
+++ b/src/test/java/io/spoud/KafkaSynthClientTest.java
@@ -68,6 +68,20 @@ public class KafkaSynthClientTest {
     }
 
     @Test
+    @DisplayName("Send-error-rate metrics are recorded")
+    public void testSendErrorRateRecorded() {
+        kafkaCompanion.consumeWithDeserializers(ByteArrayDeserializer.class)
+                .fromTopics(config.topic(), 30)
+                .awaitCompletion(Duration.ofSeconds(5));
+
+        var metrics = RestAssured.get("/q/metrics").asString();
+
+        assertThat(metrics).contains("synth_client_producer_error_rate{rack=\"dc1\"} 0.0");
+
+        lifecycle.shutdown();
+    }
+
+    @Test
     @DisplayName("Ack latency metrics are recorded")
     public void testAckLatencyRecorded() {
         kafkaCompanion.consumeWithDeserializers(ByteArrayDeserializer.class)


### PR DESCRIPTION
This should provide a more robust way of querying producer metrics (specifically the produce error rate) as it does not rely on JMX beans.

Closes #50 